### PR TITLE
Potential fix for code scanning alert no. 31: Database query built from user-controlled sources

### DIFF
--- a/routes/dreams.js
+++ b/routes/dreams.js
@@ -42,7 +42,20 @@ router.get("/:id", async (req, res) => {
 });
 
 router.put("/:id", async (req, res) => {
-  await Dream.findByIdAndUpdate(req.params.id, req.body);
+  const allowedFields = ["title", "description", "dream"];
+  const updates = {};
+
+  for (const field of allowedFields) {
+    if (Object.prototype.hasOwnProperty.call(req.body, field)) {
+      updates[field] = req.body[field];
+    }
+  }
+
+  await Dream.findOneAndUpdate(
+    { _id: req.params.id, user: req.session.user.id },
+    { $set: updates },
+    { runValidators: true }
+  );
   res.redirect("/dreams");
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/31](https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/31)

Use a **whitelisted update object** built from explicit allowed fields in `req.body`, and avoid passing raw `req.body` to Mongoose update APIs.

Best fix here (without changing intended functionality broadly): in `routes/dreams.js` at the `PUT "/:id"` route, replace `Dream.findByIdAndUpdate(req.params.id, req.body)` with:
1. Construct `updates` from allowed keys only (for example `title`, `description`, `dream`, depending on your model fields).
2. Call `findOneAndUpdate` scoped by both `_id` and `user` to preserve per-user ownership checks already used elsewhere in this file.
3. Use `$set: updates` so request payload is treated as data, not as an operator document.
4. Optionally add `{ runValidators: true }` to enforce schema validation on update.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
