### PR TITLE
Potential fix for code scanning alert no. 27: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "multer": "^2.0.2",
     "nodemon": "^3.1.11",
     "path": "^0.12.7",
-    "lusca": "^1.7.0"
+    "lusca": "^1.7.0",
+    "express-rate-limit": "^8.4.1"
   }
 }

--- a/routes/tasks.js
+++ b/routes/tasks.js
@@ -1,14 +1,23 @@
 const express = require('express');
 const router = express.Router();
+const rateLimit = require('express-rate-limit');
 const { index, create, destroy } = require('../controllers/task.controller');
+
+const tasksLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
 // Route to display all message boards
-router.get('/projects/:id/tasks',index);
+router.get('/projects/:id/tasks', tasksLimiter, index);
 
 // Route to handle the message board creation form submission
-router.post('/projects/:id/tasks',create);
+router.post('/projects/:id/tasks', tasksLimiter, create);
 
 
-router.delete('/projects/:projectId/tasks/:taskId',destroy);
+router.delete('/projects/:projectId/tasks/:taskId', tasksLimiter, destroy);
 
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/27](https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/27)

Add a rate-limiting middleware to this router and apply it to the task routes that can trigger DB work (especially `destroy`, plus `index`/`create` for comprehensive coverage). The best approach is to use `express-rate-limit`, define one limiter instance with a reasonable window and max, then pass it as middleware before each handler.

In `routes/tasks.js`:
- Add `const rateLimit = require('express-rate-limit');`
- Define `const tasksLimiter = rateLimit({...})` near router setup.
- Update the three route declarations to include `tasksLimiter` before controller handlers.

This preserves existing functionality while adding throttling controls.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
