### PR TITLE
Potential fix for code scanning alert no. 29: Database query built from user-controlled sources

### DIFF
--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -7,6 +7,11 @@ const signupSchema = Joi.object({
     password: Joi.string().required(),
   });
 
+const loginSchema = Joi.object({
+  username: Joi.string().required(),
+  password: Joi.string().required(),
+});
+
 const signup = async (req, res) => {
     try {
       const { error } = signupSchema.validate(req.body);
@@ -14,7 +19,7 @@ const signup = async (req, res) => {
         return res.status(400).json({ error: error.details[0].message });
       }
   
-      const existingUser = await User.findOne({ username: req.body.username });
+      const existingUser = await User.findOne({ username: { $eq: req.body.username } });
       if (existingUser) {
         return res.status(400).json({ error: 'Username already exists' });
       }
@@ -43,8 +48,13 @@ const signup = async (req, res) => {
 
   const login = async (req, res) => {
     try {
+      const { error } = loginSchema.validate(req.body);
+      if (error) {
+        return res.status(400).json({ error: error.details[0].message });
+      }
+
       // First Stop, does the user exist
-      const user = await User.findOne({ username: req.body.username });
+      const user = await User.findOne({ username: { $eq: req.body.username } });
       if (user) {
         const result = await bcrypt.compare(req.body.password, user.password);
         if (result) {


### PR DESCRIPTION
Potential fix for [https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/29](https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/29)

Use both of these defenses:
1. Validate `login` input with Joi (like `signup`) so `username`/`password` must be strings.
2. In Mongo query filters, wrap user-controlled values with `$eq` so they are treated as literal values, not query objects.

Best minimal fix in `controllers/auth.controller.js`:
- Add a `loginSchema` near `signupSchema`.
- In `login`, validate `req.body` against `loginSchema` and return `400` on validation failure.
- Change both `User.findOne({ username: req.body.username })` calls (signup and login) to `User.findOne({ username: { $eq: req.body.username } })`.

No functionality change for normal valid requests; this only hardens query construction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
