### PR TITLE
Potential fix for code scanning alert no. 30: Database query built from user-controlled sources

### DIFF
--- a/controllers/project.controller.js
+++ b/controllers/project.controller.js
@@ -41,7 +41,19 @@ const create = async (req, res) => {
   } 
 
   const update = async (req, res) => {
-    await Project.findByIdAndUpdate(req.params.id, req.body);
+    const allowedFields = ["name", "description", "status", "deadline"];
+    const updates = {};
+
+    for (const field of allowedFields) {
+      if (Object.prototype.hasOwnProperty.call(req.body, field)) {
+        updates[field] = req.body[field];
+      }
+    }
+
+    await Project.findOneAndUpdate(
+      { _id: req.params.id, user: req.session.user.id },
+      { $set: updates }
+    );
     res.redirect("/projects");
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/30](https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/30)

Use an allowlist-based update object instead of passing `req.body` directly to MongoDB/Mongoose.  
Best fix here: in `controllers/project.controller.js`, update the `update` handler to build a safe `updates` object from explicitly permitted fields and then pass that object to `findByIdAndUpdate`. Also ensure ownership is enforced in the update query (consistent with `show`/`edit`) by matching both `_id` and `user`.

Concretely, replace line 44 logic with:
- Read allowed fields from `req.body` into a new plain object (`updates`).
- Perform `Project.findOneAndUpdate({ _id: req.params.id, user: req.session.user.id }, { $set: updates })`.
- Keep redirect behavior unchanged.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
