### PR TITLE
Potential fix for code scanning alert no. 35: Missing rate limiting

### DIFF
--- a/routes/dreams.js
+++ b/routes/dreams.js
@@ -5,11 +5,19 @@ const router = require("express").Router();
 const User = require("../models/User");
 const Dream = require("../models/Dreams");
 const auth = require("./authMiddleware");
+const rateLimit = require("express-rate-limit");
 
 ///////////////////////////////
 // Router Specific Middleware
 ////////////////////////////////
 router.use(auth);
+
+const dreamsWriteLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 write requests per windowMs
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 ///////////////////////////////
 // Router Routes
@@ -41,7 +49,7 @@ router.get("/:id", async (req, res) => {
   }
 });
 
-router.put("/:id", async (req, res) => {
+router.put("/:id", dreamsWriteLimiter, async (req, res) => {
   const allowedFields = ["title", "description", "dream"];
   const updates = {};
 


### PR DESCRIPTION
Potential fix for [https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/35](https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/35)

To fix this without changing existing functionality, add a rate-limiting middleware and apply it to the expensive route(s), specifically the flagged `PUT /:id` endpoint. The best approach is to use `express-rate-limit`, define a limiter near the router middleware section, and pass it as middleware on the PUT route before the async handler. This preserves existing auth and business logic while adding request throttling.

In `routes/dreams.js`:
- Add `const rateLimit = require("express-rate-limit");` with the other imports.
- Define a limiter (for example, 100 requests per 15 minutes) after `router.use(auth);`.
- Update line 44 route definition to `router.put("/:id", dreamsWriteLimiter, async (req, res) => { ... })`.

This is minimal, explicit, and directly addresses the CodeQL finding on the flagged handler.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
