### PR TITLE
Potential fix for code scanning alert no. 21: Missing rate limiting

### DIFF
--- a/routes/projects.js
+++ b/routes/projects.js
@@ -18,10 +18,15 @@ const writeLimiter = rateLimit({
   max: 30,
 });
 
+const readLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+});
+
 ///////////////////////////////
 // Router Routes
 ////////////////////////////////
-router.get("/", async (req, res) => {
+router.get("/", readLimiter, async (req, res) => {
   const projects = await Project.find({ user: req.session.user.id });
   console.log(projects);
   res.render("projects/index", {


### PR DESCRIPTION
Potential fix for [https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/21](https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/21)

Apply a rate limiter to the read route that performs the DB access (`GET "/"`), without altering existing behavior for write routes.

Best fix in this file:
- Keep `writeLimiter` as-is for mutating endpoints.
- Add a dedicated `readLimiter` (or reuse `writeLimiter`) and attach it to `router.get("/")`.
- This is minimally invasive and preserves route logic, rendering, and auth behavior.

Concretely in `routes/projects.js`:
1. Define `readLimiter` after the existing `writeLimiter`.
2. Change line with `router.get("/", async (req, res) => { ... })` to `router.get("/", readLimiter, async (req, res) => { ... })`.

No new imports are needed because `express-rate-limit` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
