### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/routes/attachments.js
+++ b/routes/attachments.js
@@ -1,15 +1,22 @@
 const express = require('express');
 const router = express.Router();
 const multer = require('multer');
+const rateLimit = require('express-rate-limit');
 const Attachment = require('../models/Attachment');
 const Project = require('../models/Project');
 const fs = require('fs');
 const { index, download, destroy, create, newAttachment } = require('../controllers/attachment.controller');
 const upload = multer({ dest: 'uploads/' });
+const attachmentCreateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false
+});
 
 router.get('/projects/:id/attachments/new', newAttachment);
 
-router.post('/projects/:id/attachments', upload.single('file'), create);
+router.post('/projects/:id/attachments', attachmentCreateLimiter, upload.single('file'), create);
 
 router.get('/projects/:id/attachments', index);
 


### PR DESCRIPTION
Potential fix for [https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/2](https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/2)

Add a dedicated rate-limiting middleware to `routes/attachments.js` and apply it to the upload route on line 12. The best non-breaking fix is to use `express-rate-limit` with a reasonable window and max requests, then insert the limiter before `upload.single('file')` so abusive requests are rejected before file handling and DB work occur.

Concretely in `routes/attachments.js`:
- Add `const rateLimit = require('express-rate-limit');` near other imports.
- Define an `attachmentCreateLimiter` instance (for example, 15-minute window, capped requests per IP, standard headers enabled).
- Update the POST route to:  
  `router.post('/projects/:id/attachments', attachmentCreateLimiter, upload.single('file'), create);`

This preserves existing functionality for normal traffic while reducing DoS risk on the expensive endpoint.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
