### PR TITLE
Potential fix for code scanning alert no. 6: Missing rate limiting

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -6,21 +6,29 @@ const User = require("../models/User");
 const bcrypt = require("bcryptjs");
 const Joi = require('joi');
 const { signup, login } = require("../controllers/auth.controller");
+const rateLimit = require("express-rate-limit");
 
 const { check } = require("express-validator");
+
+const authLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 20, // limit each IP to 20 auth requests per window
+  standardHeaders: true,
+  legacyHeaders: false,
+});
 
 router.get("/signup", (req, res) => {
   res.render("auth/signup");
 });
 
 
-router.post("/signup",signup);
+router.post("/signup", authLimiter, signup);
 
 router.get("/login", (req, res) => {
   res.render("auth/login");
 });
 
-router.post("/login", login);
+router.post("/login", authLimiter, login);
 
 router.get("/logout", (req, res) => {
   req.session.user = null


### PR DESCRIPTION
Potential fix for [https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/6](https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/6)

Add an Express rate-limiting middleware and apply it to the sensitive auth POST routes before their handlers, without changing existing business logic.

Best fix in this file:
- Import `express-rate-limit`.
- Define a limiter instance (for example 15-minute window, capped requests).
- Attach it to `/signup` and `/login` POST routes by inserting the limiter before `signup`/`login`.

Edits are only in `routes/auth.js`:
1. Add `const rateLimit = require("express-rate-limit");` near other imports.
2. Define `const authLimiter = rateLimit({...})` after imports.
3. Change:
   - `router.post("/signup", signup);` → `router.post("/signup", authLimiter, signup);`
   - `router.post("/login", login);` → `router.post("/login", authLimiter, login);`

This preserves existing functionality while adding request throttling to the expensive/auth-sensitive endpoints.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
