### PR TITLE
Potential fix for code scanning alert no. 32: Clear text transmission of sensitive cookie

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,6 +32,8 @@ app.use(
     secret: SECRET,
     cookie: {
       maxAge: 1000 * 60 * 60 * 24 * 7,
+      secure: true,
+      httpOnly: true,
     },
     saveUninitialized: true,
     resave: true,


### PR DESCRIPTION
Potential fix for [https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/32](https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/32)

To fix this safely, configure the session cookie with the `secure` attribute so browsers only send it over HTTPS. In Express, this is done in the `session({...})` options under `cookie`.

Best fix in this file (without changing app behavior beyond security hardening):
- In `server.js`, inside the existing `cookie` object (lines around 33–35), add:
  - `secure: true` to enforce HTTPS-only cookie transmission.
  - `httpOnly: true` as an additional hardening measure (prevents JavaScript access to session cookie).
- Keep existing options intact (`maxAge`, `saveUninitialized`, `resave`, store config, etc.).

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
