### PR TITLE
Potential fix for code scanning alert no. 34: Information exposure through a stack trace

### DIFF
--- a/controllers/auth.controller.js
+++ b/controllers/auth.controller.js
@@ -70,7 +70,8 @@ const signup = async (req, res) => {
         res.status(400).json({ error: "User Does Not Exist" });
       }
     } catch (error) {
-      res.status(400).json(error);
+      console.error(error);
+      return res.status(500).json({ error: "Server error" });
     }
   }
   


### PR DESCRIPTION
Potential fix for [https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/34](https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/34)

General fix: never send raw caught exceptions to clients. Log detailed error information server-side, and return a generic error message/status to the user.

Best fix for this file: update the `catch` block in `login` (around lines 72–74) to:
1. Log the error on the server (`console.error(error)`), and
2. Return a generic 500 response such as `{ error: "Server error" }`.

This preserves functionality (request fails with JSON error), avoids leaking stack-trace/internal exception data, and aligns with how `signup` already handles exceptions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
