### PR TITLE
Potential fix for code scanning alert no. 17: Missing rate limiting

### DIFF
--- a/routes/message_boards.js
+++ b/routes/message_boards.js
@@ -1,9 +1,19 @@
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const router = express.Router();
 const MessageBoard = require('../models/MessageBoard');
 const Project = require('../models/Project');
 const Message = require('../models/Message');
 const { index, newMessageBoard, create, show, destroy, edit, update } = require('../controllers/message_board.controller');
+
+const messageBoardLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+  standardHeaders: true,
+  legacyHeaders: false
+});
+
+router.use(messageBoardLimiter);
 
 // Route to display all message boards
 router.get('/projects/:id/message-boards',index);


### PR DESCRIPTION
Potential fix for [https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/17](https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/17)

To fix this, add a rate-limiting middleware and apply it to this router (or at minimum to the mutating endpoints, especially `PUT` and `POST`/`DELETE`). The best low-risk fix in this file is to use `express-rate-limit` and apply it with `router.use(...)` so all message-board routes in this router are protected consistently, including the flagged `update` route and the other variant at the same location.

**Changes needed in `routes/message_boards.js`:**
1. Add import: `const rateLimit = require('express-rate-limit');`
2. Define a limiter instance with a reasonable window/max.
3. Attach it to the router before route declarations: `router.use(messageBoardLimiter);`

This does not change route behavior/functionality besides rejecting excessive request bursts with HTTP 429, which is the intended security control.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
