### PR TITLE
Potential fix for code scanning alert no. 18: Missing rate limiting

### DIFF
--- a/routes/dreams.js
+++ b/routes/dreams.js
@@ -19,6 +19,13 @@ const dreamsWriteLimiter = rateLimit({
   legacyHeaders: false,
 });
 
+const dreamsReadLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 300, // limit each IP to 300 read requests per windowMs
+  standardHeaders: true,
+  legacyHeaders: false,
+});
+
 ///////////////////////////////
 // Router Routes
 ////////////////////////////////
@@ -36,7 +43,7 @@ router.post("/", async (req, res) => {
   res.redirect("/dreams/");
 });
 
-router.get("/:id", async (req, res) => {
+router.get("/:id", dreamsReadLimiter, async (req, res) => {
   const id = req.params.id;
   const dream = await Dream.findOne({ _id: id, user: req.session.user.id });
   console.log(dream)


### PR DESCRIPTION
Potential fix for [https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/18](https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/18)

To fix this without changing core functionality, attach a rate-limiting middleware to the flagged `GET /:id` route (and preferably also to similar DB-backed read routes in this router). Since `express-rate-limit` is already imported and configured for writes, define a dedicated read limiter (typically with a higher threshold than writes) and apply it to `GET` handlers that hit the database.

Best targeted change in `routes/dreams.js`:
- Add a new limiter definition (for read requests) near the existing `dreamsWriteLimiter`.
- Update `router.get("/:id", ...)` to `router.get("/:id", dreamsReadLimiter, async (req, res) => { ... })`.

This preserves behavior while adding throttling against abusive request bursts.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
