### PR TITLE
Potential fix for code scanning alert no. 37: Missing rate limiting

### DIFF
--- a/routes/projects.js
+++ b/routes/projects.js
@@ -41,7 +41,7 @@ router.post("/", writeLimiter, create);
 
 router.get("/:id", show);
 
-router.get("/:id/edit", edit);
+router.get("/:id/edit", readLimiter, edit);
 
 router.put("/:id", writeLimiter, update);
 


### PR DESCRIPTION
Potential fix for [https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/37](https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/37)

Add the existing `readLimiter` middleware to the `GET /:id/edit` route so requests to this DB-backed read handler are throttled like other read endpoints.

Best single fix (no behavior change beyond protection):
- In `routes/projects.js`, modify the route definition on line 44 from:
  - `router.get("/:id/edit", edit);`
  to:
  - `router.get("/:id/edit", readLimiter, edit);`

No new imports, dependencies, or helper methods are needed because `readLimiter` is already defined in this file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
