### PR TITLE
Potential fix for code scanning alert no. 13: Missing rate limiting

### DIFF
--- a/routes/dreams.js
+++ b/routes/dreams.js
@@ -29,7 +29,7 @@ const dreamsReadLimiter = rateLimit({
 ///////////////////////////////
 // Router Routes
 ////////////////////////////////
-router.get("/", async (req, res) => {
+router.get("/", dreamsReadLimiter, async (req, res) => {
   const dreams = await Dream.find({ user: req.session.user.id });
   console.log(dreams);
   res.render("dreams/index", {


### PR DESCRIPTION
Potential fix for [https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/13](https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/13)

Add rate-limiting middleware to the `router.get("/")` route so the database-backed read operation is bounded per client/IP, consistent with the existing `dreamsReadLimiter` policy already defined in this file.

Best fix without changing functionality:
- In `routes/dreams.js`, update the route definition for line 32 from:
  - `router.get("/", async (req, res) => { ... })`
  to:
  - `router.get("/", dreamsReadLimiter, async (req, res) => { ... })`
- Reuse the already-declared `dreamsReadLimiter` (lines 22–27), so no new imports, config objects, or dependencies are needed.
- This preserves existing behavior while adding throttling.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
