### PR TITLE
Potential fix for code scanning alert no. 38: Missing rate limiting

### DIFF
--- a/routes/projects.js
+++ b/routes/projects.js
@@ -39,7 +39,7 @@ router.get("/new", newProject);
 router.post("/", writeLimiter, create);
 
 
-router.get("/:id", show);
+router.get("/:id", readLimiter, show);
 
 router.get("/:id/edit", readLimiter, edit);
 


### PR DESCRIPTION
Potential fix for [https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/38](https://github.com/azizdevfull/azizcamp-nodejs/security/code-scanning/38)

Add the existing `readLimiter` middleware to the `GET /:id` route so requests to `show` are rate-limited the same way as other read endpoints.

Best single fix without changing functionality:
- In `routes/projects.js`, update the route at line 42 from:
  - `router.get("/:id", show);`
  to:
  - `router.get("/:id", readLimiter, show);`
- No new imports, methods, or dependencies are required, because `readLimiter` is already defined in the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
